### PR TITLE
Strip out ASCII colors with sed

### DIFF
--- a/completions/bash
+++ b/completions/bash
@@ -15,7 +15,7 @@ _ppl()
   # Complete nicknames
   nick_cmds=([age]="" [bday]="" [email]="" [mv]="" [name]="" [nick]="" [org]="" [phone]="" [post]="" [rm]="" [show]="" [url]="")
   if [[ $nick_cmds[${prev}] ]]; then
-    local nicknames=$(for x in `ppl nick | cut -d ':' -f 1`; do echo ${x} ; done )
+    local nicknames=$(for x in `ppl nick | cut -d ':' -f 1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"`; do echo ${x} ; done )
     COMPREPLY=( $(compgen -W "${nicknames}" -- ${cur}) )
     return 0
   fi

--- a/completions/zsh
+++ b/completions/zsh
@@ -2,7 +2,7 @@
 #autoload
 
 _ppl_contacts() {
-  contacts=(`ppl nick | cut -d ':' -f 1`)
+  contacts=(`ppl nick | cut -d ':' -f 1 | sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g"`)
 }
 
 local -a _1st_arguments


### PR DESCRIPTION
I do think a `--no-color` option is a better long-term fix, but here's something for the meantime.
