### PR TITLE
Fix the version related error

### DIFF
--- a/lib/ppl.rb
+++ b/lib/ppl.rb
@@ -1,10 +1,6 @@
 require "rubygems"
 
 module Ppl
-
-  spec = Gem::Specification::load("ppl.gemspec")
-  Version = spec.nil? ? "" : spec.version
-
   module Adapter
   end
 

--- a/lib/ppl/command/shell.rb
+++ b/lib/ppl/command/shell.rb
@@ -35,7 +35,7 @@ class Ppl::Command::Shell < Ppl::Application::Command
 
   def welcome_user(input, output)
     if input.stdin.tty?
-      output.line("ppl #{Ppl::Version} (type \"exit\" to leave)")
+      output.line("ppl #{Ppl::VERSION} (type \"exit\" to leave)")
     end
   end
 

--- a/lib/ppl/command/version.rb
+++ b/lib/ppl/command/version.rb
@@ -10,7 +10,7 @@ class Ppl::Command::Version < Ppl::Application::Command
   end
 
   def execute(input, output)
-    output.line("ppl version #{Ppl::Version}")
+    output.line("ppl version #{Ppl::VERSION}")
     true
   end
 

--- a/lib/ppl/version.rb
+++ b/lib/ppl/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ppl
-  VERSION = '4.0.3'.freeze
+  VERSION = '4.0.4'.freeze
 end

--- a/lib/ppl/version.rb
+++ b/lib/ppl/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Ppl
+  VERSION = '4.0.3'.freeze
+end

--- a/ppl.gemspec
+++ b/ppl.gemspec
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'lib/ppl/version'
+
 Gem::Specification.new do |spec|
 
   spec.name = "ppl"
-  spec.version = "4.0.3"
+  spec.version = Ppl::VERSION
   spec.date = "2021-04-02"
 
   spec.required_ruby_version = ">= 3.0.0"

--- a/ppl.gemspec
+++ b/ppl.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("pry")
   spec.add_development_dependency("rspec")
   spec.add_development_dependency("rake")
-  spec.add_development_dependency("fakefs")
+  spec.add_development_dependency("fakefs", "~> 1.9.0")
 
   spec.authors = ["Henry Catalini Smith"]
   spec.email = "henry@catalinismith.com"

--- a/spec/ppl/command/shell_spec.rb
+++ b/spec/ppl/command/shell_spec.rb
@@ -88,7 +88,7 @@ describe Ppl::Command::Shell do
       allow(@input.stdin).to receive(:tty?) { true }
       expect(@output).to receive(:line) do |line|
         expect(line).to include "ppl"
-        expect(line).to include Ppl::Version
+        expect(line).to include Ppl::VERSION
       end
       expect(Readline).to receive(:readline).and_return(false)
       allow(@command).to receive(:terminate_gracefully)

--- a/spec/ppl/command/version_spec.rb
+++ b/spec/ppl/command/version_spec.rb
@@ -15,7 +15,7 @@ describe Ppl::Command::Version do
   describe "#execute" do
     it "should show the version number" do
       expect(@output).to receive(:line) do |line|
-        expect(line).to include Ppl::Version
+        expect(line).to include Ppl::VERSION
       end
       expect(@command.execute(@input, @output)).to eq true
     end


### PR DESCRIPTION
I ran into the Version error myself, and I think it is the same problem as reported in #89.
When I ran the test suite, I also saw a similar error.

So, I have updated the version string to be stored in the constant `Ppl::VERSION`, defined in the `lib/ppl/version.rb` file. This fixes the issue in the test suite, which probably means it fixes the issue for real.

Additionally, I needed to limit the version of FakeFS which is used, because of a method which is removed in v2.0. I will have a look at fixing this, but I did not want to add another change into this PR.

@henrycatalinismith as always, thank you for your work maintaining this gem! Please let me know if there are any changes you would like me to make to this PR.