### PR TITLE
Switch exists? to exist? for compatibility with Ruby 3.2.0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 task :disable_config do
   pplconfig = File.expand_path("~/.pplconfig")
   bkpconfig = File.expand_path("~/.pplconfig.bkp")
-  if File.exists? pplconfig
+  if File.exist? pplconfig
     FileUtils.mv pplconfig, bkpconfig
   end
   at_exit { Rake::Task["enable_config"].invoke }
@@ -18,7 +18,7 @@ end
 task :enable_config do
   pplconfig = File.expand_path("~/.pplconfig")
   bkpconfig = File.expand_path("~/.pplconfig.bkp")
-  if File.exists? bkpconfig
+  if File.exist? bkpconfig
     FileUtils.mv bkpconfig, pplconfig
   end
 end

--- a/lib/ppl/adapter/storage/disk.rb
+++ b/lib/ppl/adapter/storage/disk.rb
@@ -6,7 +6,7 @@ class Ppl::Adapter::Storage::Disk < Ppl::Adapter::Storage
   attr_accessor :vcard_adapter
 
   def self.create_address_book(path)
-    if !Dir.exists? path
+    if !Dir.exist? path
       FileUtils.mkdir_p(path)
     end
     storage = self.new(Dir.new(path))
@@ -41,7 +41,7 @@ class Ppl::Adapter::Storage::Disk < Ppl::Adapter::Storage
   def load_contact(id)
     filename = filename_for_contact_id(id)
     contact  = nil
-    if File.exists?(filename)
+    if File.exist?(filename)
       vcard   = File.read filename
       contact = @vcard_adapter.decode(vcard)
       if !contact.nil? && contact.is_a?(Ppl::Entity::Contact)

--- a/lib/ppl/adapter/storage/factory.rb
+++ b/lib/ppl/adapter/storage/factory.rb
@@ -12,7 +12,7 @@ class Ppl::Adapter::Storage::Factory
 
     adapter = disk_adapter
 
-    if File.exists?(git_dir)
+    if File.exist?(git_dir)
       git_adapter = Ppl::Adapter::Storage::Git.new(disk_adapter)
       git_adapter.vcard_adapter = @vcard_adapter
       adapter = git_adapter

--- a/lib/ppl/application/configuration.rb
+++ b/lib/ppl/application/configuration.rb
@@ -64,9 +64,9 @@ class Ppl::Application::Configuration
     end
     filename     = File.expand_path(USER_CONFIG)
     @user_config = {}
-    if File.exists?(filename)
+    if File.exist?(filename)
       @user_config = IniFile::load(filename).to_h
-    elsif File.exists?(xdg_path)
+    elsif File.exist?(xdg_path)
       @user_config = IniFile::load(xdg_path).to_h
     end
     return @user_config

--- a/lib/ppl/command/completion.rb
+++ b/lib/ppl/command/completion.rb
@@ -26,7 +26,7 @@ class Ppl::Command::Completion < Ppl::Application::Command
 
   def require_completion_existence(shell_name)
     path = File.join(@completions_directory.path, shell_name)
-    if !File.exists? path
+    if !File.exist? path
       raise Ppl::Error::CompletionNotFound, shell_name
     end
     path

--- a/ppl.gemspec
+++ b/ppl.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("inifile", "3.0.0")
   spec.add_dependency("mail", "2.7.1")
   spec.add_dependency("morphine", "0.1.1")
-  spec.add_dependency("rugged", "1.1.0")
+  spec.add_dependency("rugged", "1.7.2")
   spec.add_dependency("vpim", "13.11.11")
 
   spec.add_development_dependency("cucumber")

--- a/spec/ppl/adapter/storage/disk_spec.rb
+++ b/spec/ppl/adapter/storage/disk_spec.rb
@@ -11,7 +11,7 @@ describe Ppl::Adapter::Storage::Disk, "#create_address_book" do
   describe "#create_address_book" do
     it "should create the directory if it doesn't exist yet" do
       Ppl::Adapter::Storage::Disk.create_address_book("/contacts")
-      expect(Dir.exists?("/contacts")).to eq true
+      expect(Dir.exist?("/contacts")).to eq true
       FileUtils.rm_rf("/contacts")
     end
     it "should return a Ppl::Adapter::Storage::Disk" do
@@ -130,7 +130,7 @@ describe Ppl::Adapter::Storage::Disk do
       FileUtils.touch "/contacts/test.vcf"
       @contact.id = "test"
       @storage.delete_contact(@contact)
-      expect(File.exists?("/contacts/test.vcf")).to eq false
+      expect(File.exist?("/contacts/test.vcf")).to eq false
     end
   end
 

--- a/spec/ppl/command/completion_spec.rb
+++ b/spec/ppl/command/completion_spec.rb
@@ -18,7 +18,7 @@ describe Ppl::Command::Completion do
 
     before(:each) do
       allow(@directory).to receive(:path).and_return("")
-      allow(File).to receive(:exists?).and_return(true)
+      allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:read)
     end
 
@@ -29,7 +29,7 @@ describe Ppl::Command::Completion do
 
     it "should raise an error if the shell is not recognised" do
       @input.arguments = ["invalidshell"]
-      expect(File).to receive(:exists?).with("/invalidshell").and_return(false)
+      expect(File).to receive(:exist?).with("/invalidshell").and_return(false)
       expect{@command.execute(@input, @output)}.to raise_error(Ppl::Error::CompletionNotFound)
     end
 


### PR DESCRIPTION
## Installing rugged 1.1.0 fails on Ruby 3.2.0

```
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Using vpim 13.11.11 (was 24.2.20)
Installing rugged 1.1.0 (was 1.7.2) with native extensions
iGem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/henrycatalinismith/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rugged-1.1.0/ext/rugged
/Users/henrycatalinismith/.rbenv/versions/3.2.2/bin/ruby extconf.rb
checking for gmake... yes
checking for cmake... yes
checking for pkg-config... yes
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/Users/henrycatalinismith/.rbenv/versions/3.2.2/bin/$(RUBY_BASE_NAME)
        --with-sha1dc
        --without-sha1dc
        --use-system-libraries
extconf.rb:101:in `block in <main>': undefined method `exists?' for Dir:Class (NoMethodError)

    Dir.mkdir("build") if !Dir.exists?("build")
                              ^^^^^^^^
Did you mean?  exist?
        from extconf.rb:100:in `chdir'
        from extconf.rb:100:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:
```

Calls to `exists?` in the repo itself also need replacing.

Creating a PR as part of this fix to see if CI still works.